### PR TITLE
Have checkAllowedItem make sure air is not allowed.

### DIFF
--- a/src/main/java/com/sk89q/commandbook/CommandBookPlugin.java
+++ b/src/main/java/com/sk89q/commandbook/CommandBookPlugin.java
@@ -513,7 +513,7 @@ public class CommandBookPlugin extends JavaPlugin {
         if (id < 1 || (id > 96 && id < 256)
                 || (id > 359 && id < 2256)
                 || id > 2257) {
-            if (Material.getMaterial(id) == null) {
+            if (Material.getMaterial(id) == null || id == 0) {
                 throw new CommandException("Non-existent item specified.");
             }
         }


### PR DESCRIPTION
It seemed that while the first if condition was true, with a less than 0
item id, bukkit seemed to hand back not null for the
Material.getMaterial(id) call, which caused either client or server
crashes.

Let me know if my logic is totally off or not please.
