### PR TITLE
fixed HomeCommands

### DIFF
--- a/src/main/java/com/sk89q/commandbook/commands/HomeCommands.java
+++ b/src/main/java/com/sk89q/commandbook/commands/HomeCommands.java
@@ -103,7 +103,7 @@ public class HomeCommands {
             homeName = player.getName();
             loc = player.getLocation();
         } else if (args.argsLength() == 1) {
-            homeName = args.getString(1);
+            homeName = args.getString(0);
             player = plugin.checkPlayer(sender);
             loc = player.getLocation();
             


### PR DESCRIPTION
for args length == 1 it was reading the inexistent second argument instead of the first
