### PR TITLE
Add bukkit repo to maven

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,10 @@
   </scm>
 
   <repositories>
+        <repository>
+        <id>bukkit-repo</id>
+        <url>http://repo.bukkit.org/artifactory/repo</url>
+    </repository>
     <repository>
       <id>sk89q-mvn2</id>
       <url>http://mvn2.sk89q.com/repo</url>


### PR DESCRIPTION
This makes sure that you always compile with the latest version.

For this to work, you have to remove org.bukkit from http://mvn2.sk89q.com/repo, or it might not.
