### PR TITLE
allow teleport from console

### DIFF
--- a/src/main/java/com/sk89q/commandbook/commands/TeleportCommands.java
+++ b/src/main/java/com/sk89q/commandbook/commands/TeleportCommands.java
@@ -99,7 +99,13 @@ public class TeleportCommands {
             
             // Check permissions!
             plugin.checkPermission(sender, "commandbook.teleport.other");
-            if (!plugin.checkPlayer(sender).getLocation().getWorld().getName().equals(loc.getWorld().getName())) {
+            Player playerSender = null;
+            try {
+            	playerSender = plugin.checkPlayer(sender);
+            } catch (CommandException e) {
+            	// assume it's from console, skip commandbook.teleport.other check. no need to log this?
+            }
+            if (playerSender != null && !playerSender.getLocation().getWorld().getName().equals(loc.getWorld().getName())) {
                 plugin.checkPermission(sender, loc.getWorld(), "commandbook.teleport.other");
             }
         }


### PR DESCRIPTION
Previously, one could not teleport players from console when this plugin is installed.
This patch ignores checkPlayer exception (which should only ever be that the command sender is not a player, therefore is console) is ignored if there are two playernames supplied.
