### PR TITLE
allow teleport from console

### DIFF
--- a/src/main/java/com/sk89q/commandbook/commands/TeleportCommands.java
+++ b/src/main/java/com/sk89q/commandbook/commands/TeleportCommands.java
@@ -99,7 +99,7 @@ public class TeleportCommands {
             
             // Check permissions!
             plugin.checkPermission(sender, "commandbook.teleport.other");
-            if (!plugin.checkPlayer(sender).getLocation().getWorld().getName().equals(loc.getWorld().getName())) {
+            if (sender instanceof Player && !plugin.checkPlayer(sender).getLocation().getWorld().getName().equals(loc.getWorld().getName())) {
                 plugin.checkPermission(sender, loc.getWorld(), "commandbook.teleport.other");
             }
         }


### PR DESCRIPTION
Previously, one could not teleport players from console when this plugin is installed.
This patch skips checkPlayer if sender is not a Player and there are two playernames supplied.
