### PR TITLE
Fix for damage values >255

### DIFF
--- a/src/main/java/com/sk89q/commandbook/CommandBookPlugin.java
+++ b/src/main/java/com/sk89q/commandbook/CommandBookPlugin.java
@@ -1241,8 +1241,7 @@ public final class CommandBookPlugin extends JavaPlugin {
                 return null;
             }
         }
-        
-        return new ItemStack(id, 1, (short)dmg, (byte)dmg);
+        return new ItemStack(id, 1, (short)dmg);
     }
     
     /**
@@ -1291,8 +1290,7 @@ public final class CommandBookPlugin extends JavaPlugin {
         if (dataName != null) {            
             dmg = matchItemData(id, dataName);
         }
-        
-        return new ItemStack(id, 1, (short)dmg, (byte)dmg);
+        return new ItemStack(id, 1, (short)dmg);
     }
     
     /**


### PR DESCRIPTION
CraftBukkit will truncate the damage value if a fourth parameter to the ItemStack constructor is provided. This fixes it.
