### PR TITLE
Fix redundant message when teleporting others and add silent flag

### DIFF
--- a/src/main/java/com/sk89q/commandbook/locations/TeleportComponent.java
+++ b/src/main/java/com/sk89q/commandbook/locations/TeleportComponent.java
@@ -85,7 +85,8 @@ public class TeleportComponent extends AbstractComponent implements Listener {
     public class Commands {
 
         @Command(aliases = {"teleport", "tp"}, usage = "[target] <destination>",
-                desc = "Teleport to a location", min = 1, max = 2)
+                desc = "Teleport to a location",
+                flags = "s", min = 1, max = 2)
         @CommandPermissions({"commandbook.teleport"})
         public void teleport(CommandContext args, CommandSender sender) throws CommandException {
 
@@ -110,7 +111,8 @@ public class TeleportComponent extends AbstractComponent implements Listener {
                 }
             }
 
-            (new TeleportPlayerIterator(sender, loc)).iterate(targets);
+            boolean silent = args.hasFlag('s');
+            (new TeleportPlayerIterator(sender, loc, silent)).iterate(targets);
         }
 
         @Command(aliases = {"call"}, usage = "<target>", desc = "Request a teleport", min = 1, max = 1)

--- a/src/main/java/com/sk89q/commandbook/locations/WarpsComponent.java
+++ b/src/main/java/com/sk89q/commandbook/locations/WarpsComponent.java
@@ -43,7 +43,9 @@ public class WarpsComponent extends LocationsComponent {
     }
 
     public class Commands {
-        @Command(aliases = {"warp"}, usage = "[world] [target] <warp>", desc = "Teleport to a warp", min = 1, max = 3)
+        @Command(aliases = {"warp"},
+                usage = "[world] [target] <warp>", desc = "Teleport to a warp",
+                flags = "s", min = 1, max = 3)
         @CommandPermissions({"commandbook.warp.teleport"})
         public void warp(CommandContext args, CommandSender sender) throws CommandException {
             Iterable<Player> targets = null;
@@ -81,7 +83,8 @@ public class WarpsComponent extends LocationsComponent {
                 throw new CommandException("A warp by the given name does not exist.");
             }
 
-            (new TeleportPlayerIterator(sender, loc)).iterate(targets);
+            boolean silent = args.hasFlag('s');
+            (new TeleportPlayerIterator(sender, loc, silent)).iterate(targets);
         }
 
         @Command(aliases = {"setwarp"}, usage = "<warp> [location]", desc = "Set a warp", min = 1, max = 2)

--- a/src/main/java/com/sk89q/commandbook/util/TeleportPlayerIterator.java
+++ b/src/main/java/com/sk89q/commandbook/util/TeleportPlayerIterator.java
@@ -28,10 +28,16 @@ public class TeleportPlayerIterator extends PlayerIteratorAction {
     
     protected Location loc;
     protected Location oldLoc;
+    protected boolean silent;
     
     public TeleportPlayerIterator(CommandSender sender, Location loc) {
+        this(sender, loc, false);
+    }
+
+    public TeleportPlayerIterator(CommandSender sender, Location loc, boolean silent) {
         super(sender);
         this.loc = loc;
+        this.silent = silent;
     }
     
     @Override
@@ -47,6 +53,9 @@ public class TeleportPlayerIterator extends PlayerIteratorAction {
     
     @Override
     public void onVictim(CommandSender sender, Player player) {
+        if (silent)
+            return;
+
         if (oldLoc.getWorld().equals(loc.getWorld())) {
             player.sendMessage(ChatColor.YELLOW + "You've been teleported by "
                     + PlayerUtil.toName(sender) + ".");


### PR DESCRIPTION
Currently, when you teleport another player (/tp bob #target), they get the message "You've been teleported by AgentME." _and_ the message "Teleported by AgentME.". The first commit removes that second redundant message.
The second commit here adds a -s flag to /tp and /warp, which causes it so when you teleport other players, it doesn't give them any message indicating who sent them or that they were even teleported.
