### PR TITLE
"glitchy" item stacking option

### DIFF
--- a/src/main/java/com/sk89q/commandbook/CommandBook.java
+++ b/src/main/java/com/sk89q/commandbook/CommandBook.java
@@ -107,7 +107,6 @@ public final class CommandBook extends BasePlugin {
 		final CommandsManagerRegistration cmdRegister = new CommandsManagerRegistration(this, commands);
         if (lowPriorityCommandRegistration) {
             getServer().getScheduler().scheduleSyncDelayedTask(this, new Runnable() {
-                @Override
                 public void run() {
                     cmdRegister.register(CommandBookCommands.CommandBookParentCommand.class);
                 }

--- a/src/main/java/com/sk89q/commandbook/InventoryComponent.java
+++ b/src/main/java/com/sk89q/commandbook/InventoryComponent.java
@@ -37,6 +37,7 @@ import org.bukkit.inventory.ItemStack;
 
 import java.util.Collections;
 import java.util.Set;
+import java.util.logging.Logger;
 
 import static com.sk89q.commandbook.util.ItemUtil.*;
 import static com.sk89q.commandbook.CommandBookUtil.giveItem;
@@ -64,6 +65,7 @@ public class InventoryComponent extends BukkitComponent {
         @Setting("allowed-items") public Set<Integer> allowedItems = Collections.emptySet();
         @Setting("disllowed-items") public Set<Integer> disallowedItems = Collections.emptySet();
         @Setting("default-item-stack-size") public int defaultItemStackSize = 1;
+        @Setting("stack-glitchy-items") public boolean stackGlitchyItems = false;
     }
 
     // -- Helper methods
@@ -411,8 +413,10 @@ public class InventoryComponent extends BukkitComponent {
                         // Same type?
                         // Blocks store their color in the damage value
                         if (item2.getTypeId() == item.getTypeId() &&
-                                ((!ItemType.usesDamageValue(item.getTypeId()) && ignoreDamaged)
-                                        || item.getDurability() == item2.getDurability()) &&
+                                ((ItemType.usesDamageValue(item.getTypeId()) && ignoreDamaged)
+                                        || !ItemType.usesDamageValue(item.getTypeId())) &&
+                                (ItemType.isGlitchyStack(item.getTypeId()) && config.stackGlitchyItems
+                                		|| !ItemType.isGlitchyStack(item.getTypeId())) && 
                                 item.getEnchantments().equals(item2.getEnchantments())) {
                             // This stack won't fit in the parent stack
                             if (item2.getAmount() > needed) {

--- a/src/main/java/com/sk89q/commandbook/bans/FlatFileBanDatabase.java
+++ b/src/main/java/com/sk89q/commandbook/bans/FlatFileBanDatabase.java
@@ -275,12 +275,10 @@ public class FlatFileBanDatabase implements BanDatabase {
         throw new UnsupportedOperationException("Importing to legacy ban storage provider not supported.");
     }
 
-    @Override
     public Ban getBannedName(String name) {
         return bannedNames.get(name);
     }
 
-    @Override
     public Ban getBannedAddress(String address) {
         return null;
     }


### PR DESCRIPTION
I added an option here to stack "glitchy" items, which means items that behave weirdly or brokenly when stacked. An example is tools. When a stack of tools is used, the durability of all of them goes down.
