### PR TITLE
Add amount check to fix crash

### DIFF
--- a/src/main/java/com/sk89q/commandbook/CommandBookUtil.java
+++ b/src/main/java/com/sk89q/commandbook/CommandBookUtil.java
@@ -245,6 +245,7 @@ public class CommandBookUtil {
             // Check to see if the player can give stacks
             CommandBook.inst().checkPermission(sender, "commandbook.give.stacks");
         }
+        if(amt > 2240) amt = 2240;
 
         // Get a nice amount name
         String amtText = amt == -1 ? "an infinite stack of" : String.valueOf(amt);


### PR DESCRIPTION
If a value given while spawning items is very large, the server will freeze up while looping addItem().

Executing  "/item 1 2147483647" will freeze up a server, no matter how powerful it is.

This pull request adds a simple check to the amount; if the amount given is larger than 2240(max amount of slots in inventory) it is set to 2240.
