### PR TITLE
Set all hunger variables to their sensible defaults with /heal

### DIFF
--- a/src/main/java/com/sk89q/commandbook/PlayerComponent.java
+++ b/src/main/java/com/sk89q/commandbook/PlayerComponent.java
@@ -150,8 +150,8 @@ public class PlayerComponent extends BukkitComponent {
             for (Player player : targets) {
                 player.setHealth(20);
                 player.setFoodLevel(20);
-                player.setSaturation(5.0);
-                player.setExhaustion(0.0);
+                player.setSaturation(5);
+                player.setExhaustion(0);
 
                 // Tell the user
                 if (player.equals(sender)) {


### PR DESCRIPTION
setHeath and setFoodLevel were already being set, but setExhaustion and setSaturation are both very important variables for the food mechanic in Minecraft.
