### PR TITLE
Multiple-home support

### DIFF
--- a/src/main/java/com/sk89q/commandbook/locations/HomesComponent.java
+++ b/src/main/java/com/sk89q/commandbook/locations/HomesComponent.java
@@ -43,7 +43,7 @@ public class HomesComponent extends LocationsComponent {
     }
 
     public class Commands {
-        @Command(aliases = {"home"}, usage = "[world] [target] [owner] [home]", desc = "Teleport to a home", min = 0, max = 4)
+        @Command(aliases = {"home"}, usage = "[world] [target] [home]", desc = "Teleport to a home", min = 0, max = 3)
         @CommandPermissions({"commandbook.home.teleport"})
         public void home(CommandContext args, CommandSender sender) throws CommandException {
             Iterable<Player> targets = null;
@@ -58,16 +58,8 @@ public class HomesComponent extends LocationsComponent {
             } else if (args.argsLength() == 1) {
                 Player player = PlayerUtil.checkPlayer(sender);
                 targets = PlayerUtil.matchPlayers(player);
-                try {
-                    home = getManager().get(player.getWorld(), PlayerUtil.matchPlayerExactly(player, args.getString(0)).getName());
-                } catch (CommandException e) {
-                    home = getManager().get(player.getWorld(), player.getName() + "@" + args.getString(0));
-                }
+                home = getManager().get(player.getWorld(), args.getString(0));
             } else if (args.argsLength() == 2) {
-                Player player = PlayerUtil.checkPlayer(sender);
-                targets = PlayerUtil.matchPlayers(player);
-                home = getManager().get(player.getWorld(), PlayerUtil.matchPlayerExactly(player, args.getString(0)).getName() + "@" + args.getString(1));
-            } else if (args.argsLength() == 3) {
                 targets = PlayerUtil.matchPlayers(sender, args.getString(0));
                 if (getManager().isPerWorld()) {
                     Player player = PlayerUtil.checkPlayer(sender);
@@ -83,14 +75,10 @@ public class HomesComponent extends LocationsComponent {
                         break;
                     }
                 }
-            } else if (args.argsLength() == 4) {
-                targets = PlayerUtil.matchPlayers(sender, args.getString(0));
-                if (getManager().isPerWorld()) {
-                    Player player = PlayerUtil.checkPlayer(sender);
-                    home = getManager().get(player.getWorld(), args.getString(1) + "@" + args.getString(3));
-                } else {
-                    home = getManager().get(null, args.getString(1) + "@" + args.getString(3));
-                }
+            } else if (args.argsLength() == 3) {
+                targets = PlayerUtil.matchPlayers(sender, args.getString(1));
+                home = getManager().get(
+                        LocationUtil.matchWorld(sender, args.getString(0)), args.getString(2));
 
                 // Check permissions!
                 for (Player target : targets) {
@@ -107,13 +95,13 @@ public class HomesComponent extends LocationsComponent {
                 }
                 loc = home.getLocation();
             } else {
-                throw new CommandException("A home for the given player does not exist.");
+                throw new CommandException("The given home does not exist.");
             }
 
             (new TeleportPlayerIterator(sender, loc)).iterate(targets);
         }
 
-        @Command(aliases = {"sethome"}, usage = "[owner] [location]", desc = "Set a home", min = 0, max = 3)
+        @Command(aliases = {"sethome"}, usage = "[home] [location]", desc = "Set a home", min = 0, max = 2)
         @CommandPermissions({"commandbook.home.set"})
         public void setHome(CommandContext args, CommandSender sender) throws CommandException {
             String homeName;
@@ -126,16 +114,14 @@ public class HomesComponent extends LocationsComponent {
                 homeName = player.getName();
                 loc = player.getLocation();
             } else if (args.argsLength() == 1) {
-                try {
-                	homeName = PlayerUtil.matchPlayerExactly(sender, args.getString(0)).getName();
-                } catch (CommandException e) {
-                    homeName = sender.getName() + "@" + args.getString(0);
-                }
+                homeName = args.getString(0);
                 player = PlayerUtil.checkPlayer(sender);
                 loc = player.getLocation();
 
                 // Check permissions!
-                if (!homeName.equals(sender.getName())) {
+                if (homeName.equals(sender.getName() + "@")) {
+                    CommandBook.inst().checkPermission(sender, "commandbook.home.set.multiple");
+                } else if (!homeName.equals(sender.getName())) {
                     CommandBook.inst().checkPermission(sender, "commandbook.home.set.other");
                 }
             } else if (args.argsLength() == 2) {
@@ -143,19 +129,19 @@ public class HomesComponent extends LocationsComponent {
                 loc = LocationUtil.matchLocation(sender, args.getString(0));
 
                 // Check permissions!
-                if (!homeName.equals(sender.getName())) {
+                if (homeName.equals(sender.getName() + "@")) {
+                    CommandBook.inst().checkPermission(sender, "commandbook.home.set.multiple");
+                } else if (!homeName.equals(sender.getName())) {
                     CommandBook.inst().checkPermission(sender, "commandbook.home.set.other");
                 }
             } else {
-                try {
-                	homeName = PlayerUtil.matchPlayerExactly(sender, args.getString(1)).getName();
-                } catch (CommandException e) {
-                    homeName = sender.getName() + "@" + args.getString(1);
-                }
+                homeName = sender.getName() + "@" + args.getString(1);
                 loc = LocationUtil.matchLocation(sender, args.getString(0));
 
                 // Check permissions!
-                if (!homeName.equals(sender.getName())) {
+                if (homeName.equals(sender.getName() + "@")) {
+                    CommandBook.inst().checkPermission(sender, "commandbook.home.set.multiple");
+                } else if (!homeName.equals(sender.getName())) {
                     CommandBook.inst().checkPermission(sender, "commandbook.home.set.other");
                 }
             }


### PR DESCRIPTION
This is a patch to add multi-home support to CommandBook.

I am using the standard CommandBook homes.csv format to keep backwards compatibility. However, we are using an invalid Minecraft username (containing @) to store the additional homes.
The new permission commandbook.home.set.multiple has been added to allow for permission control of homes.

There are still a few features left to be desired, one being that there is no way to list a user's home(s).

This is my first contribution to CommandBook, so I'd love some constructive criticism.
