### PR TITLE
Remove pointless message from /pong

### DIFF
--- a/src/main/java/com/sk89q/commandbook/FunComponent.java
+++ b/src/main/java/com/sk89q/commandbook/FunComponent.java
@@ -142,9 +142,7 @@ public class FunComponent extends BukkitComponent {
                 usage = "", desc = "A dummy command",
                 flags = "", min = 0, max = 0)
         public void pong(CommandContext args, CommandSender sender) throws CommandException {
-
-            sender.sendMessage(ChatColor.YELLOW +
-                    "I hear " + PlayerUtil.toColoredName(sender, ChatColor.YELLOW) + " likes cute Asian boys.");
+            sender.sendMessage(ChatColor.YELLOW + "Ping!");
         }
 
         @Command(aliases = {"spawnmob"}, usage = "<mob>[|rider] [count] [location]", desc = "Spawn a mob",


### PR DESCRIPTION
I've had to deal with several users asking why this command is in place and saying it's offensive.

Would be best to just remove sk89q's [lovely response](https://github.com/sk89q/commandbook/commit/9cf1ebe0018abe8618a88a0de41ca00914302553).
