### PR TITLE
Fixed the return command

### DIFF
--- a/src/main/java/com/sk89q/commandbook/locations/TeleportSession.java
+++ b/src/main/java/com/sk89q/commandbook/locations/TeleportSession.java
@@ -88,7 +88,7 @@ public class TeleportSession extends PersistentSession {
 
         locationHistory.add(0, location);
         while (locationHistory.size() > LOCATION_HISTORY_SIZE) {
-            locationHistory.poll();
+            locationHistory.pollLast();
         }
     }
 


### PR DESCRIPTION
The history was polled from the wrong end of the list causing any entry added to be instantly removed after the limit was reached.
