### PR TITLE
Maintain player pitch/yaw information on /tp x y z (and variants)

### DIFF
--- a/src/main/java/com/sk89q/commandbook/util/TeleportPlayerIterator.java
+++ b/src/main/java/com/sk89q/commandbook/util/TeleportPlayerIterator.java
@@ -55,6 +55,11 @@ public class TeleportPlayerIterator extends PlayerIteratorAction {
         if (relative[1]) newLoc.setY(oldLoc.getY() + loc.getY());
         if (relative[2]) newLoc.setZ(oldLoc.getZ() + loc.getZ());
 
+        if (newLoc.getPitch() == 0.0 && newLoc.getYaw() == 0.0) {
+            newLoc.setPitch(oldLoc.getPitch());
+            newLoc.setYaw(oldLoc.getYaw());
+        }
+
         newLoc.getChunk().load(true);
         if (player.getVehicle() != null) {
             player.getVehicle().eject();


### PR DESCRIPTION
In vanilla, `/tp x y z` (and variants) maintain player's pitch/yaw information. This addition helps to bring CommandBook more in compliance with vanilla behavior. If a player is a point of teleport, their Location will have a pitch/yaw of its own, and will therefore not be overwritten, but Locations generated by `x y z`, `x,y,z`, and other coordinate specific variants will allow a player to keep their pitch/yaw information.
