### PR TITLE
Fixed broken enchantment support for kits

### DIFF
--- a/src/main/java/com/sk89q/commandbook/kits/Kit.java
+++ b/src/main/java/com/sk89q/commandbook/kits/Kit.java
@@ -83,8 +83,7 @@ public class Kit {
         }
 
         for (ItemStack item : items) {
-            player.getInventory().addItem(new ItemStack(item.getType(),
-                    item.getAmount(), item.getDurability()));
+            player.getInventory().addItem(item.clone());
         }
 
         return true;


### PR DESCRIPTION
Kits should have supported enchantments (and other metadata set vie the central `getItem()` method) from the beginning. However, since a new ItemStack was created whenever distributing a kit using the standard constructor, kits broke whenever new item specifications were added somewhere in this logic.

Simply cloning the item-object set by the `getItem()` method solves this mess.
