### PR TITLE
Fixed the match for #player:playername world definition

### DIFF
--- a/src/main/java/com/sk89q/commandbook/util/LocationUtil.java
+++ b/src/main/java/com/sk89q/commandbook/util/LocationUtil.java
@@ -84,7 +84,7 @@ public class LocationUtil {
 
                 throw new CommandException("No skylands world found.");
                 // Handle getting a world from a player
-            } else if (filter.matches("^#player$")) {
+            } else if (filter.matches("^#player:[^ ]+$")) {
                 String parts[] = filter.split(":", 2);
 
                 // They didn't specify an argument for the player!


### PR DESCRIPTION
Line 87 - the original request has looked for "#player", while only "#player:playername" parameter made sense.
