### PR TITLE
Remove /summon alias as it inflicts with vanilla minecraft commands and ...

### DIFF
--- a/src/main/java/com/sk89q/commandbook/locations/TeleportComponent.java
+++ b/src/main/java/com/sk89q/commandbook/locations/TeleportComponent.java
@@ -248,7 +248,7 @@ public class TeleportComponent extends BukkitComponent implements Listener {
             target.sendMessage(targetMessage);
         }
 
-        @Command(aliases = {"bring", "tphere", "summon", "s"}, usage = "<target>", desc = "Bring a player to you", min = 1, max = 1)
+        @Command(aliases = {"bring", "tphere", "s"}, usage = "<target>", desc = "Bring a player to you", min = 1, max = 1)
         public void bring(CommandContext args, CommandSender sender) throws CommandException {
             Player player = PlayerUtil.checkPlayer(sender);
             Player target = null;


### PR DESCRIPTION
...causes problems.

The /summon alias for /bring is much of a waste as it removes the full capabilities of command blocks to spawn mobs.
