### PR TITLE
Fix javadoc warnings

### DIFF
--- a/src/main/java/com/sk89q/commandbook/CommandBookUtil.java
+++ b/src/main/java/com/sk89q/commandbook/CommandBookUtil.java
@@ -193,7 +193,7 @@ public class CommandBookUtil {
      * Get the 24-hour time string for a given Minecraft time.
      *
      * @param time
-     * @return
+     * @return the 24-hour time
      */
     public static String getTimeString(long time) {
         int hours = (int) ((time / 1000 + 8) % 24);
@@ -212,7 +212,7 @@ public class CommandBookUtil {
      *
      * @param online
      * @param color
-     * @return
+     * @return a comma seperated list of players
      */
     public static String getOnlineList(Player[] online, ChatColor color) {
         StringBuilder out = new StringBuilder();
@@ -245,7 +245,7 @@ public class CommandBookUtil {
      * Get the cardinal compass direction of a player.
      *
      * @param player
-     * @return
+     * @return the cardinal direction
      */
     public static String getCardinalDirection(Player player) {
         double rot = (player.getLocation().getYaw() - 90) % 360;
@@ -422,7 +422,7 @@ public class CommandBookUtil {
      * that free position.
      *
      * @param searchPos search position
-     * @return
+     * @return an open {@link Location}
      */
     public static Location findFreePosition(Location searchPos) {
         World world = searchPos.getWorld();
@@ -553,7 +553,7 @@ public class CommandBookUtil {
      *
      * @param sender
      * @param message
-     * @return
+     * @return the filtered string
      */
     public static String replaceMacros(CommandSender sender, String message) {
         Player[] online = CommandBook.server().getOnlinePlayers();

--- a/src/main/java/com/sk89q/commandbook/JingleNoteComponent.java
+++ b/src/main/java/com/sk89q/commandbook/JingleNoteComponent.java
@@ -66,7 +66,7 @@ public class JingleNoteComponent extends BukkitComponent implements Listener {
     /**
      * Get the jingle note manager.
      *
-     * @return
+     * @return the {@link JingleNoteManager}
      */
     public JingleNoteManager getJingleNoteManager() {
         return jingleNoteManager;

--- a/src/main/java/com/sk89q/commandbook/bans/BanDatabase.java
+++ b/src/main/java/com/sk89q/commandbook/bans/BanDatabase.java
@@ -161,7 +161,7 @@ public interface BanDatabase extends Iterable<Ban> {
      * @param address
      * @param source
      * @param reason
-     * @return
+     * @return whether the name or address was found
      */
     public boolean unban(String name, String address, CommandSender source, String reason);
 

--- a/src/main/java/com/sk89q/commandbook/bans/BansComponent.java
+++ b/src/main/java/com/sk89q/commandbook/bans/BansComponent.java
@@ -84,7 +84,7 @@ public class BansComponent extends BukkitComponent implements Listener {
     /**
      * Get the ban database.
      *
-     * @return
+     * @return the BanDatabase
      */
     public BanDatabase getBanDatabase() {
         return bans;

--- a/src/main/java/com/sk89q/commandbook/bans/FlatFileBanDatabase.java
+++ b/src/main/java/com/sk89q/commandbook/bans/FlatFileBanDatabase.java
@@ -118,7 +118,7 @@ public class FlatFileBanDatabase implements BanDatabase {
      * Read a list from file. Each line is trimmed and made lower case.
      *
      * @param file
-     * @return
+     * @return a map of Player names (Strings) to {@link Ban}s
      * @throws IOException
      */
     protected synchronized Map<String, Ban> readLowercaseList(File file) throws IOException {

--- a/src/main/java/com/sk89q/commandbook/locations/LocationManager.java
+++ b/src/main/java/com/sk89q/commandbook/locations/LocationManager.java
@@ -52,7 +52,7 @@ public interface LocationManager<T> {
      * Get by name.
      *
      * @param id The name to get
-     * @return The {@link T} if registered
+     * @return The object <i>T</i> if registered
      */
     public T get(String id);
 

--- a/src/main/java/com/sk89q/commandbook/time/TimeComponent.java
+++ b/src/main/java/com/sk89q/commandbook/time/TimeComponent.java
@@ -142,7 +142,7 @@ public class TimeComponent extends BukkitComponent implements Listener {
     /**
      * Get locked times.
      *
-     * @return
+     * @return the map of world to time values
      */
     public Map<String, Integer> getLockedTimes() {
         return lockedTimes;
@@ -167,7 +167,7 @@ public class TimeComponent extends BukkitComponent implements Listener {
      * Parse a time string.
      *
      * @param timeStr
-     * @return
+     * @return the parsed integer
      * @throws CommandException
      */
     @Deprecated

--- a/src/main/java/com/sk89q/commandbook/util/EntityUtil.java
+++ b/src/main/java/com/sk89q/commandbook/util/EntityUtil.java
@@ -81,7 +81,7 @@ public class EntityUtil {
      * Get a list of creature names.
      *
      * @param requireSpawnable Whether to only show entries that are spawnable
-     * @return
+     * @return the list of creature names in CSV form
      */
     public static String getCreatureNameList(boolean requireSpawnable) {
         StringBuilder str = new StringBuilder();

--- a/src/main/java/com/sk89q/commandbook/util/ItemUtil.java
+++ b/src/main/java/com/sk89q/commandbook/util/ItemUtil.java
@@ -36,7 +36,7 @@ public class ItemUtil {
      * Gets the name of an item.
      *
      * @param id
-     * @return
+     * @return the name of this id's corrisponding item
      */
     public static String toItemName(int id) {
         ItemType type = ItemType.fromID(id);
@@ -53,7 +53,7 @@ public class ItemUtil {
      *
      * @param id
      * @param filter
-     * @return
+     * @return the data value
      * @throws com.sk89q.minecraft.util.commands.CommandException
      */
     public static int matchItemData(int id, String filter) throws CommandException {
@@ -113,9 +113,10 @@ public class ItemUtil {
 
     /**
      * Attempt to match a dye color for sheep wool.
+     * pass in "random" for one of the random 16 {@link DyeColor}
      *
      * @param filter
-     * @return
+     * @return the {@link DyeColor}
      * @throws CommandException
      */
     public static DyeColor matchDyeColor(String filter) throws CommandException {

--- a/src/main/java/com/sk89q/commandbook/util/LocationUtil.java
+++ b/src/main/java/com/sk89q/commandbook/util/LocationUtil.java
@@ -38,10 +38,10 @@ public class LocationUtil {
 
     /**
      * Match a world.
-     * @param sender
      *
+     * @param sender
      * @param filter
-     * @return
+     * @return the world
      * @throws com.sk89q.minecraft.util.commands.CommandException
      */
     public static World matchWorld(CommandSender sender, String filter) throws CommandException {

--- a/src/main/java/com/sk89q/commandbook/util/PlayerIteratorAction.java
+++ b/src/main/java/com/sk89q/commandbook/util/PlayerIteratorAction.java
@@ -77,7 +77,7 @@ public abstract class PlayerIteratorAction {
     /**
      * Get the sender.
      * 
-     * @return
+     * @return the {@link CommandSender}
      */
     public CommandSender getSender() {
         return sender;

--- a/src/main/java/com/sk89q/commandbook/util/PlayerUtil.java
+++ b/src/main/java/com/sk89q/commandbook/util/PlayerUtil.java
@@ -41,7 +41,7 @@ public class PlayerUtil {
      * Checks to see if the sender is a player, otherwise throw an exception.
      *
      * @param sender
-     * @return
+     * @return the {@link Player} if sender is a Player
      * @throws com.sk89q.minecraft.util.commands.CommandException
      */
     public static Player checkPlayer(CommandSender sender)
@@ -57,7 +57,7 @@ public class PlayerUtil {
      * Match player names.
      *
      * @param filter
-     * @return
+     * @return the list of {@link Player}
      */
     @Deprecated
     public static List<Player> matchPlayerNames(String filter) {
@@ -70,7 +70,7 @@ public class PlayerUtil {
      *
      * @param source
      * @param filter
-     * @return
+     * @return the list of {@link Player}
      */
     public static List<Player> matchPlayerNames(CommandSender source, String filter) {
 
@@ -140,7 +140,7 @@ public class PlayerUtil {
      * throw an exception.
      *
      * @param players
-     * @return
+     * @return iterator for players
      * @throws CommandException
      */
     protected static Iterable<Player> checkPlayerMatch(List<Player> players)
@@ -225,7 +225,7 @@ public class PlayerUtil {
      *
      * @param sender
      * @param filter
-     * @return
+     * @return the matching player
      * @throws CommandException
      */
     public static Player matchPlayerExactly(CommandSender sender, String filter)
@@ -247,7 +247,7 @@ public class PlayerUtil {
      *
      * @param sender
      * @param filter
-     * @return
+     * @return the matching player
      * @throws CommandException
      */
     public static Player matchSinglePlayer(CommandSender sender, String filter)
@@ -273,7 +273,7 @@ public class PlayerUtil {
      *
      * @param sender
      * @param filter
-     * @return
+     * @return the {@link CommandSender}
      * @throws CommandException
      */
     public static CommandSender matchPlayerOrConsole(CommandSender sender, String filter)
@@ -303,7 +303,7 @@ public class PlayerUtil {
      * Gets the name of a command sender. This may be a display name.
      *
      * @param sender
-     * @return
+     * @return the name of this {@link CommandSender}
      */
     public static String toName(CommandSender sender) {
         return ChatColor.stripColor(toColoredName(sender, null));
@@ -314,7 +314,7 @@ public class PlayerUtil {
      *
      * @param sender
      * @param endColor
-     * @return
+     * @return the colored name of this {@link CommandSender}
      */
     public static String toColoredName(CommandSender sender, ChatColor endColor) {
         if (sender instanceof Player) {
@@ -337,7 +337,7 @@ public class PlayerUtil {
      * method should never return a "display name".
      *
      * @param sender
-     * @return
+     * @return the name of this {@link CommandSender}
      */
     public static String toUniqueName(CommandSender sender) {
         if (sender instanceof Player) {

--- a/src/main/java/com/sk89q/jinglenote/JingleNotePlayer.java
+++ b/src/main/java/com/sk89q/jinglenote/JingleNotePlayer.java
@@ -30,7 +30,6 @@ public abstract class JingleNotePlayer implements Runnable {
      * 
      * @param player The player who is hearing this's name.
      * @param seq The JingleSequencer to play.
-     * @param area The SearchArea for this player. (optional)
      */
     public JingleNotePlayer(String player, JingleSequencer seq) {
         this.player = player;


### PR DESCRIPTION
There was several incomplete javadoc comment blocks, fixed them up.
1. @return needs a param
2. The JD tool (or at least the 1.6 one) doesn't support {@link T} reference replacement
3. Had an extra unused @param from old code still in there
