### PR TITLE
Checked teleports

### DIFF
--- a/src/main/java/com/sk89q/commandbook/locations/SpawnLocationsComponent.java
+++ b/src/main/java/com/sk89q/commandbook/locations/SpawnLocationsComponent.java
@@ -129,8 +129,8 @@ public class SpawnLocationsComponent extends BukkitComponent implements Listener
             (new PlayerIteratorAction(sender) {
 
                 @Override
-                public void perform(Player player) {
-                    PlayerUtil.teleportTo(sender, player, getSpawnManager().getWorldSpawn(player.getWorld()), true);
+                public boolean perform(Player player) {
+                    return PlayerUtil.teleportTo(sender, player, getSpawnManager().getWorldSpawn(player.getWorld()), true);
                 }
 
                 @Override

--- a/src/main/java/com/sk89q/commandbook/util/entity/player/PlayerUtil.java
+++ b/src/main/java/com/sk89q/commandbook/util/entity/player/PlayerUtil.java
@@ -18,16 +18,12 @@
 
 package com.sk89q.commandbook.util.entity.player;
 
-import com.google.common.collect.Lists;
 import com.sk89q.commandbook.CommandBook;
-import com.sk89q.commandbook.util.InputUtil;
-import com.sk89q.minecraft.util.commands.CommandContext;
 import com.sk89q.minecraft.util.commands.CommandException;
 import org.bukkit.Location;
 import org.bukkit.command.CommandSender;
-import org.bukkit.entity.*;
-
-import java.util.List;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
 
 public class PlayerUtil {
 
@@ -54,16 +50,16 @@ public class PlayerUtil {
      * @param target
      * @param allowVehicles
      */
-    public static void teleportTo(CommandSender sender, Player player, Location target, boolean allowVehicles) {
+    public static boolean teleportTo(CommandSender sender, Player player, Location target, boolean allowVehicles) {
         target.getChunk().load(true);
         if (player.getVehicle() != null) {
             Entity vehicle = player.getVehicle();
             vehicle.eject();
 
-            player.teleport(target);
+            boolean success = player.teleport(target);
 
             if (!allowVehicles) {
-                return;
+                return success;
             }
 
             // Check vehicle permissions
@@ -72,12 +68,13 @@ public class PlayerUtil {
             if (CommandBook.inst().hasPermission(player, permString)) {
                 if (player.getWorld().equals(target.getWorld())
                         || CommandBook.inst().hasPermission(player, target.getWorld(), permString)) {
-                    vehicle.teleport(player);
+                    success = success && vehicle.teleport(player);
                     vehicle.setPassenger(player);
                 }
             }
+            return success;
         } else {
-            player.teleport(target);
+            return player.teleport(target);
         }
     }
 }

--- a/src/main/java/com/sk89q/commandbook/util/entity/player/iterators/PlayerIteratorAction.java
+++ b/src/main/java/com/sk89q/commandbook/util/entity/player/iterators/PlayerIteratorAction.java
@@ -49,7 +49,7 @@ public abstract class PlayerIteratorAction {
      */
     public void iterate(Iterable<Player> targets) {
         for (Player player : targets) {
-            perform(player);
+            if (!perform(player)) continue;
             
             // Tell the user
             if (player.equals(sender)) {
@@ -88,7 +88,7 @@ public abstract class PlayerIteratorAction {
      * 
      * @param player
      */
-    public abstract void perform(Player player);
+    public abstract boolean perform(Player player);
     
     /**
      * Called when the caller is affected by the action.

--- a/src/main/java/com/sk89q/commandbook/util/entity/player/iterators/TeleportPlayerIterator.java
+++ b/src/main/java/com/sk89q/commandbook/util/entity/player/iterators/TeleportPlayerIterator.java
@@ -48,7 +48,7 @@ public class TeleportPlayerIterator extends PlayerIteratorAction {
     }
 
     @Override
-    public void perform(Player player) {
+    public boolean perform(Player player) {
         oldLoc = player.getLocation();
         Location newLoc = loc;
         // for each coord, if it is relative, add the given location's coord
@@ -62,12 +62,12 @@ public class TeleportPlayerIterator extends PlayerIteratorAction {
             newLoc.setYaw(oldLoc.getYaw());
         }
 
-        teleport(player, newLoc);
+        return teleport(player, newLoc);
     }
 
-    public void teleport(Player player, Location newLoc) {
+    public boolean teleport(Player player, Location newLoc) {
 
-        PlayerUtil.teleportTo(sender, player, newLoc, true);
+        return PlayerUtil.teleportTo(sender, player, newLoc, true);
     }
 
     @Override


### PR DESCRIPTION
This fixes an issue where a plugin could cancel a teleport event, but CommandBook would act as though the teleport was entirely successful
