### PR TITLE
Fixed multiple enchantings on items

### DIFF
--- a/src/main/java/com/sk89q/commandbook/kits/FlatFileKitsManager.java
+++ b/src/main/java/com/sk89q/commandbook/kits/FlatFileKitsManager.java
@@ -100,7 +100,7 @@ public class FlatFileKitsManager implements KitManager {
                     continue;
                 }
 
-                String[] parts = line.split(",");
+                String[] parts = line.split("#");
                 ItemStack item = ItemUtil.getItem(parts[0].replace(" ", ""));
 
                 if (item == null) {


### PR DESCRIPTION
Previosly enchantings and the item amount was seperated by a ","
This causes the ItemUtil.getComamndItem() method to only get one of the enchantments.
I changed the amount to be seperated by a "#"
